### PR TITLE
Telegram: Senden zu Chats gefixt

### DIFF
--- a/src/lib/notification.ts
+++ b/src/lib/notification.ts
@@ -425,7 +425,7 @@ export class NotificationClass extends library.BaseClass {
                                     for (const chatid of chatids) {
                                         this.adapter.sendTo(this.options.adapter, 'send', {
                                             ...opt,
-                                            chatid: chatid,
+                                            chatId: chatid,
                                         });
                                     }
                                 } else {


### PR DESCRIPTION
Beim Senden von Nachrichten von Telegram-Nachrichten wurde leider bisher die ChatID ignoriert. Dieser Pull-Request fixt das und setzt die chatId-Property beim sendTo korrekt.